### PR TITLE
Add spacebar guessing to match GeoGuessr

### DIFF
--- a/src/routes/GameManager.js
+++ b/src/routes/GameManager.js
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 
 import HiddenLocation from "../components/HiddenLocation";
 import OSRSMap from "../components/OSRSMap";
@@ -132,6 +132,24 @@ function GameManager() {
       }
     }
   }
+
+  /**
+   * Adds and removes the listener to bind spacebar to submitting a guess.
+   * Note that this currently has no dependency array and will run every render.
+   * Consider pulling `submitGuess` and its dependencies out of the component or
+   * into useCallbacks if this becomes a problem.
+   */
+  useEffect(() => {
+    const spacebarHandler = (event) => {
+      // match on several different spacebar codes for browser support
+      if (event.key === " " || event.code === "Space" || event.keyCode === 32) submitGuess();
+    }
+    window.addEventListener("keydown", spacebarHandler);
+
+    return () => {
+      window.removeEventListener("keydown", spacebarHandler);
+    }
+  });
 
   return (
     <div>


### PR DESCRIPTION
Slamming that space bar now submits the guess just like GeoGuessr!

I called this out in the comment but this is going to run on every rerender since `submitGuess` is being defined inside the component. Shouldn't be a problem given how infrequently this renders but left that note just in case.